### PR TITLE
Fix various typos

### DIFF
--- a/component/indiclient/indibaseclient.pas
+++ b/component/indiclient/indibaseclient.pas
@@ -228,7 +228,7 @@ begin
   FreeOnTerminate := True;
   FlockBlobEvent := False;
   FMissedFrameCount := 0;
-  Ftrace := False;  // for debuging only
+  Ftrace := False;  // for debugging only
   Fdevices := TObjectList.Create;
   FwatchDevices := TStringList.Create;
 end;

--- a/component/indiclient/indiblobclient.pas
+++ b/component/indiclient/indiblobclient.pas
@@ -203,7 +203,7 @@ begin
   FreeOnTerminate := True;
   FlockBlobEvent := False;
   FMissedFrameCount := 0;
-  Ftrace := False;  // for debuging only
+  Ftrace := False;  // for debugging only
   Fdevices := TObjectList.Create;
   FwatchDevices := TStringList.Create;
 end;

--- a/component/synapse/blcksock.pas
+++ b/component/synapse/blcksock.pas
@@ -55,7 +55,7 @@ initialized on constructor of TBlockSocket class for each socket separately.
 Socket interface is used only if your need it.
 
 If you leave this directive here, then socket interface is loaded and
-initialized only once at start of your program! It boost performace on high
+initialized only once at start of your program! It boost performance on high
 count of created and destroyed sockets. It eliminate possible small resource
 leak on Windows systems too.
 }
@@ -152,18 +152,18 @@ type
 
   {:Types of OnStatus events}
   THookSocketReason = (
-    {:Resolving is begin. Resolved IP and port is in parameter in format like:
+    {:Resolving has begun. Resolved IP and port is in parameter in format like:
      'localhost.somewhere.com:25'.}
     HR_ResolvingBegin,
-    {:Resolving is done. Resolved IP and port is in parameter in format like:
+    {:Resolving is completed. Resolved IP and port is in parameter in format like:
      'localhost.somewhere.com:25'. It is always same as in HR_ResolvingBegin!}
     HR_ResolvingEnd,
-    {:Socket created by CreateSocket method. It reporting Family of created
+    {:Socket created by CreateSocket method. It reports Family of created
      socket too!}
     HR_SocketCreate,
     {:Socket closed by CloseSocket method.}
     HR_SocketClose,
-    {:Socket binded to IP and Port. Binded IP and Port is in parameter in format
+    {:Socket binded to IP and Port. Bound IP and Port is in parameter in format
      like: 'localhost.somewhere.com:25'.}
     HR_Bind,
     {:Socket connected to IP and Port. Connected IP and Port is in parameter in
@@ -173,21 +173,21 @@ type
     HR_CanRead,
     {:Called when CanWrite method is used with @True result.}
     HR_CanWrite,
-    {:Socket is swithed to Listen mode. (TCP socket only)}
+    {:Socket is switched to Listen mode. (TCP socket only)}
     HR_Listen,
     {:Socket Accepting client connection. (TCP socket only)}
     HR_Accept,
-    {:report count of bytes readed from socket. Number is in parameter string.
+    {:report count of bytes read from socket. Number is in parameter string.
      If you need is in integer, you must use StrToInt function!}
     HR_ReadCount,
-    {:report count of bytes writed to socket. Number is in parameter string. If
-     you need is in integer, you must use StrToInt function!}
+    {:report count of bytes written to socket. Number is in parameter string. If
+     you need an integer, you must use StrToInt function!}
     HR_WriteCount,
-    {:If is limiting of bandwidth on, then this reason is called when sending or
-     receiving is stopped for satisfy bandwidth limit. Parameter is count of
+    {:If limiting of bandwidth is enabled, then this reason is called when sending or
+     receiving is stopped to satisfy bandwidth limit. Parameter is count of
      waiting milliseconds.}
     HR_Wait,
-    {:report situation where communication error occured. When raiseexcept is
+    {:report situation where communication error occurred. When raiseexcept is
      @true, then exception is called after this Hook reason.}
     HR_Error
     );
@@ -210,11 +210,11 @@ type
     const Buffer: TMemory; Len: Integer) of object;
 
   {:This procedural type is used for hook OnAfterConnect. By this hook you can
-   insert your code after TCP socket has been sucessfully connected.}
+   insert your code after TCP socket has been successfully connected.}
   THookAfterConnect = procedure(Sender: TObject) of object;
 
   {:This procedural type is used for hook OnVerifyCert. By this hook you can
-   insert your additional certificate verification code. Usefull to verify server
+   insert your additional certificate verification code. Useful to verify server
    CN against URL. }
 
   THookVerifyCert = function(Sender: TObject):boolean of object;
@@ -228,7 +228,7 @@ type
   TSocketFamily = (
     {:Default mode. Socket family is defined by target address for connection.
      It allows instant access to IPv4 and IPv6 nodes. When you need IPv6 address
-     as destination, then is used IPv6 mode. othervise is used IPv4 mode.
+     as destination, then is used IPv6 mode. otherwise is used IPv4 mode.
      However this mode not working properly with preliminary IPv6 supports!}
     SF_Any,
     {:Turn this class to pure IPv4 mode. This mode is totally compatible with
@@ -382,9 +382,9 @@ type
 
     {:If @link(family) is not SF_Any, then create socket with type defined in
      @link(Family) property. If family is SF_Any, then do nothing! (socket is
-     created automaticly when you know what type of socket you need to create.
+     created automatically when you know what type of socket you need to create.
      (i.e. inside @link(Connect) or @link(Bind) call.) When socket is created,
-     then is aplyed all stored delayed socket options.}
+     then is applied all stored delayed socket options.}
     procedure CreateSocket;
 
     {:It create socket. Address resolving of Value tells what type of socket is
@@ -403,12 +403,12 @@ type
      symbolic ('192.168.74.50', 'cosi.nekde.cz', 'ff08::1'). The same for PORT
      - it may be number or mnemonic port ('23', 'telnet').
 
-     If port value is '0', system chooses itself and conects unused port in the
+     If port value is '0', system chooses itself and connects unused port in the
      range 1024 to 4096 (this depending by operating system!). Structure
      LocalSin is filled after calling this method.
 
      Note: If you call this on non-created socket, then socket is created
-     automaticly.
+     automatically.
 
      Warning: when you call : Bind('0.0.0.0','0'); then is nothing done! In this
      case is used implicit system bind instead.}
@@ -421,7 +421,7 @@ type
      Structures LocalSin and RemoteSin will be filled with valid values.
 
      When you call this on non-created socket, then socket is created
-     automaticly. Type of created socket is by @link(Family) property. If is
+     automatically. Type of created socket is by @link(Family) property. If is
      used SF_IP4, then is created socket for IPv4. If is used SF_IP6, then is
      created socket for IPv6. When you have family on SF_Any (default!), then
      type of created socket is determined by address resolving of destination
@@ -447,7 +447,7 @@ type
 
     {:Send data string via connected socket. Any terminator is not added! If you
      need send true string with CR-LF termination, you must add CR-LF characters
-     to sended string! Because any termination is not added automaticly, you can
+     to sent string! Because any termination is not added automatically, you can
      use this function for sending any binary data in binary string.}
     procedure SendString(Data: AnsiString); virtual;
 
@@ -455,7 +455,7 @@ type
     procedure SendInteger(Data: integer); virtual;
 
     {:Send data as one block to socket. Each block begin with 4 bytes with
-     length of data in block. This 4 bytes is added automaticly by this
+     length of data in block. This 4 bytes is added automatically by this
      function.}
     procedure SendBlock(const Data: AnsiString); virtual;
 
@@ -479,7 +479,7 @@ type
      On stream oriented sockets if is received 0 bytes, it mean 'socket is
      closed!"
 
-     On datagram socket is readed first waiting datagram.}
+     On datagram socket is read first waiting datagram.}
     function RecvBuffer(Buffer: TMemory; Length: Integer): Integer; virtual;
 
     {:Note: This is high-level receive function. It using internal
@@ -489,11 +489,11 @@ type
      Method waits until data is received. If no data is received within TIMEOUT
      (in milliseconds) period, @link(LastError) is set to WSAETIMEDOUT. Methods
      serves for reading any size of data (i.e. one megabyte...). This method is
-     preffered for reading from stream sockets (like TCP).}
+     preferred for reading from stream sockets (like TCP).}
     function RecvBufferEx(Buffer: Tmemory; Len: Integer;
       Timeout: Integer): Integer; virtual;
 
-    {:Similar to @link(RecvBufferEx), but readed data is stored in binary
+    {:Similar to @link(RecvBufferEx), but read data is stored in binary
      string, not in memory buffer.}
     function RecvBufferStr(Len: Integer; Timeout: Integer): AnsiString; virtual;
 
@@ -547,18 +547,18 @@ type
      TIMEOUT (in milliseconds) period, @link(LastError) is set to WSAETIMEDOUT.
      Methods serves for reading unknown size of data. Because before call this
      function you don't know size of received data, returned data is stored in
-     dynamic size binary string. This method is preffered for reading from
+     dynamic size binary string. This method is preferred for reading from
      stream sockets (like TCP). It is very goot for receiving datagrams too!
      (UDP protocol)}
     function RecvPacket(Timeout: Integer): AnsiString; virtual;
 
     {:Read one block of data from socket. Each block begin with 4 bytes with
-     length of data in block. This function read first 4 bytes for get lenght,
+     length of data in block. This function read first 4 bytes for get length,
      then it wait for reported count of bytes.}
     function RecvBlock(Timeout: Integer): AnsiString; virtual;
 
     {:Read all data from socket to stream until socket is closed (or any error
-     occured.)}
+     occurred.)}
     procedure RecvStreamRaw(const Stream: TStream; Timeout: Integer); virtual;
     {:Read requested count of bytes from socket to stream.}
     procedure RecvStreamSize(const Stream: TStream; Timeout: Integer; Size: int64);
@@ -570,12 +570,12 @@ type
     in Indy library. It using @link(RecvBlock) method.}
     procedure RecvStreamIndy(const Stream: TStream; Timeout: Integer); virtual;
 
-    {:Same as @link(RecvBuffer), but readed data stays in system input buffer.
+    {:Same as @link(RecvBuffer), but read data stays in system input buffer.
     Warning: this function not respect data in @link(LineBuffer)! Is not
     recommended to use this function!}
     function PeekBuffer(Buffer: TMemory; Length: Integer): Integer; virtual;
 
-    {:Same as @link(RecvByte), but readed data stays in input system buffer.
+    {:Same as @link(RecvByte), but read data stays in input system buffer.
      Warning: this function not respect data in @link(LineBuffer)! Is not
     recommended to use this function!}
     function PeekByte(Timeout: Integer): Byte; virtual;
@@ -639,7 +639,7 @@ type
     {:Try resolve symbolic port name to port number. (i.e. 'Echo' to 8)}
     function ResolvePort(Port: string): Word;
 
-    {:Set information about remote side socket. It is good for seting remote
+    {:Set information about remote side socket. It is good for setting remote
      side for sending UDP packet, etc.}
     procedure SetRemoteSin(IP, Port: string);
 
@@ -658,7 +658,7 @@ type
     {:Return @TRUE, if you can read any data from socket or is incoming
      connection on TCP based socket. Status is tested for time Timeout (in
      milliseconds). If value in Timeout is 0, status is only tested and
-     continue. If value in Timeout is -1, run is breaked and waiting for read
+     continue. If value in Timeout is -1, run is broken and waiting for read
      data maybe forever.
 
      This function is need only on special cases, when you need use
@@ -673,13 +673,13 @@ type
     {:Return @TRUE, if you can to socket write any data (not full sending
      buffer). Status is tested for time Timeout (in milliseconds). If value in
      Timeout is 0, status is only tested and continue. If value in Timeout is
-     -1, run is breaked and waiting for write data maybe forever.
+     -1, run is broken and waiting for write data maybe forever.
 
      This function is need only on special cases!}
     function CanWrite(Timeout: Integer): Boolean; virtual;
 
     {:Same as @link(SendBuffer), but send datagram to address from
-     @link(RemoteSin). Usefull for sending reply to datagram received by
+     @link(RemoteSin). Useful for sending reply to datagram received by
      function @link(RecvBufferFrom).}
     function SendBufferTo(const Buffer: TMemory; Length: Integer): Integer; virtual;
 
@@ -692,13 +692,13 @@ type
      @link(RemoteSin) structure contains information about sender of UDP packet.}
     function RecvBufferFrom(Buffer: TMemory; Length: Integer): Integer; virtual;
 {$IFNDEF CIL}
-    {:This function is for check for incoming data on set of sockets. Whitch
-    sockets is checked is decribed by SocketList Tlist with TBlockSocket
+    {:This function is for check for incoming data on set of sockets. Which
+    sockets is checked is described by SocketList Tlist with TBlockSocket
     objects. TList may have maximal number of objects defined by FD_SETSIZE
     constant. Return @TRUE, if you can from some socket read any data or is
     incoming connection on TCP based socket. Status is tested for time Timeout
     (in milliseconds). If value in Timeout is 0, status is only tested and
-    continue. If value in Timeout is -1, run is breaked and waiting for read
+    continue. If value in Timeout is -1, run is broken and waiting for read
     data maybe forever. If is returned @TRUE, CanReadList TList is filled by all
     TBlockSocket objects what waiting for read.}
     function GroupCanRead(const SocketList: TSocketList; Timeout: Integer;
@@ -782,7 +782,7 @@ type
      connection.}
     property RecvCounter: int64 read FRecvCounter;
 
-    {:Return count of sended bytes on this socket from begin of current
+    {:Return count of sent bytes on this socket from begin of current
      connection.}
     property SendCounter: int64 read FSendCounter;
   published
@@ -796,7 +796,7 @@ type
     {:this value is for free use.}
     property Tag: Integer read FTag write FTag;
 
-    {:If @true, winsock errors raises exception. Otherwise is setted
+    {:If @true, winsock errors raises exception. Otherwise is set
     @link(LastError) value only and you must check it from your program! Default
     value is @false.}
     property RaiseExcept: Boolean read FRaiseExcept write FRaiseExcept;
@@ -825,7 +825,7 @@ type
     property MaxBandwidth: Integer Write SetBandwidth;
 
     {:Do a conversion of non-standard line terminators to CRLF. (Off by default)
-     If @True, then terminators like sigle CR, single LF or LFCR are converted
+     If @True, then terminators like single CR, single LF or LFCR are converted
      to CRLF internally. This have effect only in @link(RecvString) method!}
     property ConvertLineEnd: Boolean read FConvertLineEnd Write FConvertLineEnd;
 
@@ -834,7 +834,7 @@ type
     property Family: TSocketFamily read FFamily Write SetFamily;
 
     {:When resolving of domain name return both IPv4 and IPv6 addresses, then
-     specify if is used IPv4 (dafault - @true) or IPv6.}
+     specify if is used IPv4 (default - @true) or IPv6.}
     property PreferIP4: Boolean read FPreferIP4 Write FPreferIP4;
 
     {:By default (@true) is all timeouts used as timeout between two packets in
@@ -842,7 +842,7 @@ type
      reading operation!}
     property InterPacketTimeout: Boolean read FInterPacketTimeout Write FInterPacketTimeout;
 
-    {:All sended datas was splitted by this value.}
+    {:All sent data was split by this value.}
     property SendMaxChunk: Integer read FSendMaxChunk Write FSendMaxChunk;
 
     {:By setting this property to @true you can stop any communication. You can
@@ -860,7 +860,7 @@ type
      create gauges for data transfers, etc.}
     property OnStatus: THookSocketStatus read FOnStatus write FOnStatus;
 
-    {:this event is good for some internal thinks about filtering readed datas.
+    {:this event is good for some internal thinks about filtering read data.
      It is used by telnet client by example.}
     property OnReadFilter: THookDataFilter read FOnReadFilter write FOnReadFilter;
 
@@ -869,7 +869,7 @@ type
      Ipv4, IPv6 or automatic mode)}
     property OnCreateSocket: THookCreateSocket read FOnCreateSocket write FOnCreateSocket;
 
-    {:This event is good for monitoring content of readed or writed datas.}
+    {:This event is good for monitoring content of read or written data.}
     property OnMonitor: THookMonitor read FOnMonitor write FOnMonitor;
 
     {:This event is good for calling your code during long socket operations.
@@ -922,7 +922,7 @@ type
      cases! (it is called internally!)}
     function SocksRequest(Cmd: Byte; const IP, Port: string): Boolean;
 
-    {:Receive response to previosly sended request. This is needed only in
+    {:Receive response to previously sent request. This is needed only in
      special cases! (it is called internally!)}
     function SocksResponse: Boolean;
 
@@ -933,7 +933,7 @@ type
     property SocksLastError: integer read FSocksLastError;
   published
     {:Address of SOCKS server. If value is empty string, SOCKS support is
-     disabled. Assingning any value to this property enable SOCKS mode.
+     disabled. Assigning any value to this property enable SOCKS mode.
      Warning: You cannot combine this mode with HTTP-tunneling mode!}
     property SocksIP: string read FSocksIP write FSocksIP;
 
@@ -946,7 +946,7 @@ type
     {:If you need authorisation on SOCKS server, set password here.}
     property SocksPassword: string read FSocksPassword write FSocksPassword;
 
-    {:Specify timeout for communicatin with SOCKS server. Default is one minute.}
+    {:Specify timeout for communicating with SOCKS server. Default is one minute.}
     property SocksTimeout: integer read FSocksTimeout write FSocksTimeout;
 
     {:If @True, all symbolic names of target hosts is not translated to IP's
@@ -955,14 +955,14 @@ type
 
     {:Specify SOCKS type. By default is used SOCKS5, but you can use SOCKS4 too.
      When you select SOCKS4, then if @link(SOCKSResolver) is enabled, then is
-     used SOCKS4a. Othervise is used pure SOCKS4.}
+     used SOCKS4a. Otherwise is used pure SOCKS4.}
     property SocksType: TSocksType read FSocksType write FSocksType;
   end;
 
   {:@abstract(Implementation of TCP socket.)
    Supported features: IPv4, IPv6, SSL/TLS or SSH (depending on used plugin),
-   SOCKS5 proxy (outgoing connections and limited incomming), SOCKS4/4a proxy
-   (outgoing connections and limited incomming), TCP through HTTP proxy tunnel.}
+   SOCKS5 proxy (outgoing connections and limited incoming), SOCKS4/4a proxy
+   (outgoing connections and limited incoming), TCP through HTTP proxy tunnel.}
   TTCPBlockSocket = class(TSocksBlockSocket)
   protected
     FOnAfterConnect: THookAfterConnect;
@@ -1026,7 +1026,7 @@ type
      protocol.)
 
      Note: If you call this on non-created socket, then socket is created
-     automaticly.}
+     automatically.}
     procedure Connect(IP, Port: string); override;
 
     {:If you need upgrade existing TCP connection to SSL/TLS (or SSH2, if plugin
@@ -1040,7 +1040,7 @@ type
 
     {:If you need use this component as SSL/TLS TCP server, then after accepting
      of inbound connection you need start SSL/TLS session by this method. Before
-     call this function, you must have assigned all neeeded certificates and
+     call this function, you must have assigned all needed certificates and
      keys!}
     function SSLAcceptConnection: Boolean;
 
@@ -1069,7 +1069,7 @@ type
      IPPROTO_TCP.}
     function GetSocketProtocol: integer; override;
 
-    {:Class implementing SSL/TLS support. It is allways some descendant
+    {:Class implementing SSL/TLS support. It is always some descendant
      of @link(TCustomSSL) class. When programmer not select some SSL plugin
      class, then is used @link(TSSLNone)}
     property SSL: TCustomSSL read FSSL;
@@ -1081,7 +1081,7 @@ type
      in SSL/TLS subsystem, it returns right error description.}
     function GetErrorDescEx: string; override;
 
-    {:Specify IP address of HTTP proxy. Assingning non-empty value to this
+    {:Specify IP address of HTTP proxy. Assigning non-empty value to this
      property enable HTTP-tunnel mode. This mode is for tunnelling any outgoing
      TCP connection through HTTP proxy server. (If policy on HTTP proxy server
      allow this!) Warning: You cannot combine this mode with SOCK5 mode!}
@@ -1101,7 +1101,7 @@ type
     {:Specify timeout for communication with HTTP proxy in HTTPtunnel mode.}
     property HTTPTunnelTimeout: integer read FHTTPTunnelTimeout Write FHTTPTunnelTimeout;
 
-    {:This event is called after sucessful TCP socket connection.}
+    {:This event is called after successful TCP socket connection.}
     property OnAfterConnect: THookAfterConnect read FOnAfterConnect write FOnAfterConnect;
   end;
 
@@ -1123,12 +1123,12 @@ type
 
   {:@abstract(Implementation of UDP socket.)
    NOTE: in this class is all receiving redirected to RecvBufferFrom. You can
-   use for reading any receive function. Preffered is RecvPacket! Similary all
+   use for reading any receive function. Preferred is RecvPacket! Similarly all
    sending is redirected to SendbufferTo. You can use for sending UDP packet any
    sending function, like SendString.
 
    Supported features: IPv4, IPv6, unicasts, broadcasts, multicasts, SOCKS5
-   proxy (only unicasts! Outgoing and incomming.)}
+   proxy (only unicasts! Outgoing and incoming.)}
   TUDPBlockSocket = class(TDgramBlockSocket)
   protected
     FSocksControlSock: TTCPBlockSocket;
@@ -1138,7 +1138,7 @@ type
   public
     destructor Destroy; override;
 
-    {:Enable or disable sending of broadcasts. If seting OK, result is @true.
+    {:Enable or disable sending of broadcasts. If setting OK, result is @true.
      This method is not supported in SOCKS5 mode! IPv6 does not support
      broadcasts! In this case you must use Multicasts instead.}
     procedure EnableBroadcast(Value: Boolean);
@@ -1156,8 +1156,8 @@ type
     {:Remove this socket from given multicast group.}
     procedure DropMulticast(MCastIP:string);
 {$ENDIF}
-    {:All sended multicast datagrams is loopbacked to your interface too. (you
-     can read your sended datas.) You can disable this feature by this function.
+    {:All sent multicast datagrams is loopbacked to your interface too. (you
+     can read your sent data.) You can disable this feature by this function.
      This function not working on some Windows systems!}
     procedure EnableMulticastLoop(Value: Boolean);
 
@@ -1169,9 +1169,9 @@ type
     function GetSocketProtocol: integer; override;
 
     {:Set Time-to-live value for multicasts packets. It define number of routers
-     for transfer of datas. If you set this to 1 (dafault system value), then
+     for transfer of data. If you set this to 1 (default system value), then
      multicasts packet goes only to you local network. If you need transport
-     multicast packet to worldwide, then increase this value, but be carefull,
+     multicast packet to worldwide, then increase this value, but be careful,
      lot of routers on internet does not transport multicasts packets!}
     property MulticastTTL: Integer read GetMulticastTTL Write SetMulticastTTL;
   end;
@@ -1286,7 +1286,7 @@ type
 
     {: Do not call this directly. It is used internally by @link(TTCPBlockSocket)!
 
-     Here is needed code for acept new SSL connection.}
+     Here is needed code for accept new SSL connection.}
     function Accept: boolean; virtual;
 
     {: Do not call this directly. It is used internally by @link(TTCPBlockSocket)!
@@ -1303,17 +1303,17 @@ type
 
     {: Do not call this directly. It is used internally by @link(TTCPBlockSocket)!
 
-     Here is needed code for sending some datas by SSL connection.}
+     Here is needed code for sending some data by SSL connection.}
     function SendBuffer(Buffer: TMemory; Len: Integer): Integer; virtual;
 
     {: Do not call this directly. It is used internally by @link(TTCPBlockSocket)!
 
-     Here is needed code for receiving some datas by SSL connection.}
+     Here is needed code for receiving some data by SSL connection.}
     function RecvBuffer(Buffer: TMemory; Len: Integer): Integer; virtual;
 
     {: Do not call this directly. It is used internally by @link(TTCPBlockSocket)!
 
-     Here is needed code for getting count of datas what waiting for read.
+     Here is needed code for getting count of data what waiting for read.
      If SSL plugin not allows this, then it should return 0.}
     function WaitingData: Integer; virtual;
 
@@ -1343,20 +1343,20 @@ type
 
     {:Return all detailed information about certificate from remote side of
      SSL/TLS connection. Result string can be multilined! Each plugin can return
-     this informations in different format!}
+     this information in different format!}
     function GetCertInfo: string; virtual;
 
     {:Return currently used Cipher.}
     function GetCipherName: string; virtual;
 
-    {:Return currently used number of bits in current Cipher algorythm.}
+    {:Return currently used number of bits in current Cipher algorithm.}
     function GetCipherBits: integer; virtual;
 
-    {:Return number of bits in current Cipher algorythm.}
+    {:Return number of bits in current Cipher algorithm.}
     function GetCipherAlgBits: integer; virtual;
 
     {:Return result value of verify remote side certificate. Look to OpenSSL
-     documentation for possible values. For example 0 is successfuly verified
+     documentation for possible values. For example 0 is successfully verified
      certificate, or 18 is self-signed certificate.}
     function GetVerifyCert: integer; virtual;
 
@@ -1445,7 +1445,7 @@ type
     property CertComplianceLevel:integer read FCertComplianceLevel write FCertComplianceLevel;
 
     {:This event is called when verifying the server certificate immediatally after
-     a successfull verification in the ssl library.}
+     a successful verification in the ssl library.}
     property OnVerifyCert: THookVerifyCert read FOnVerifyCert write FOnVerifyCert;
 
     {: Server Name Identification. Host name to send to server. If empty the host name
@@ -1471,7 +1471,7 @@ type
     VerLen: Byte;
     TOS: Byte;
     TotalLen: Word;
-    Identifer: Word;
+    Identifier: Word;
     FragOffsets: Word;
     TTL: Byte;
     Protocol: Byte;
@@ -2444,7 +2444,7 @@ begin
   s := '';
   x := 0;
   repeat
-    //get rest of FBuffer or incomming new data...
+    //get rest of FBuffer or incoming new data...
     ti := GetTick;
     s := s + RecvPacket(Timeout);
     if FLastError <> 0 then

--- a/component/synapse/clamsend.pas
+++ b/component/synapse/clamsend.pas
@@ -107,10 +107,10 @@ type
     {:Scan content of TStream by new 0.95 API.}
     function ScanStream2(const Value: TStream): AnsiString; virtual;
   published
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
 
-    {:Socket object used for TCP data transfer operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP data transfer operation. Good for setting OnStatus hook, etc.}
     property DSock: TTCPBlockSocket read FDSock;
 
     {:Can turn-on session mode of communication with ClamD. Default is @false,

--- a/component/synapse/dnssend.pas
+++ b/component/synapse/dnssend.pas
@@ -165,10 +165,10 @@ type
       const Reply: TStrings): Boolean;
   published
 
-    {:Socket object used for UDP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for UDP operation. Good for setting OnStatus hook, etc.}
     property Sock: TUDPBlockSocket read FSock;
 
-    {:Socket object used for TCP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP operation. Good for setting OnStatus hook, etc.}
     property TCPSock: TTCPBlockSocket read FTCPSock;
 
     {:if @true, then is used TCP protocol instead UDP. It is needed for zone
@@ -186,18 +186,18 @@ type
     {:@True, if answer is truncated to 512 bytes.}
     property Truncated: Boolean read FTRuncated;
 
-    {:Detailed informations from name server reply. One record per line. Record
-     have comma delimited entries with type number, TTL and data filelds.
+    {:Detailed information from name server reply. One record per line. Record
+     have comma delimited entries with type number, TTL and data fields.
      This information contains detailed information about query reply.}
     property AnswerInfo: TStringList read FAnswerInfo;
 
-    {:Detailed informations from name server reply. One record per line. Record
-     have comma delimited entries with type number, TTL and data filelds.
+    {:Detailed information from name server reply. One record per line. Record
+     have comma delimited entries with type number, TTL and data fields.
      This information contains detailed information about nameserver.}
     property NameserverInfo: TStringList read FNameserverInfo;
 
-    {:Detailed informations from name server reply. One record per line. Record
-     have comma delimited entries with type number, TTL and data filelds.
+    {:Detailed information from name server reply. One record per line. Record
+     have comma delimited entries with type number, TTL and data fields.
      This information contains detailed additional information.}
     property AdditionalInfo: TStringList read FAdditionalInfo;
   end;

--- a/component/synapse/ftpsend.pas
+++ b/component/synapse/ftpsend.pas
@@ -54,7 +54,7 @@ Used RFC: RFC-959, RFC-2228, RFC-2428
   {$MODE DELPHI}
 {$ENDIF}
 {$H+}
-{$TYPEINFO ON}// Borland changed defualt Visibility from Public to Published
+{$TYPEINFO ON}// Borland changed default Visibility from Public to Published
                 // and it requires RTTI to be generated $M+
 {$M+}
 
@@ -91,7 +91,7 @@ type
   TLogonActions = array [0..17] of byte;
 
   {:Procedural type for OnStatus event. Sender is calling @link(TFTPSend) object.
-   Value is FTP command or reply to this comand. (if it is reply, Response
+   Value is FTP command or reply to this command. (if it is reply, Response
    is @True).}
   TFTPStatus = procedure(Sender: TObject; Response: Boolean;
     const Value: string) of object;
@@ -206,7 +206,7 @@ type
     definition mask.) Mask is same as mask used in TotalCommander.}
     property Masks: TStringList read FMasks;
 
-    {:After @link(ParseLines) it holding lines what was not sucessfully parsed.}
+    {:After @link(ParseLines) it holding lines what was not successfully parsed.}
     property UnparsedLines: TStringList read FUnparsedLines;
   end;
 
@@ -305,7 +305,7 @@ type
     function List(Directory: string; NameList: Boolean): Boolean; virtual;
 
     {:Read data from FileName on FTP server. If Restore is @true and server
-     supports resume dowloads, download is resumed. (received is only rest
+     supports resume downloads, download is resumed. (received is only rest
      of file)}
     function RetrieveFile(const FileName: string; Restore: Boolean): Boolean; virtual;
 
@@ -313,10 +313,10 @@ type
      supports resume upload, upload is resumed. (send only rest of file)
      In this case if remote file is same length as local file, nothing will be
      done. If remote file is larger then local, resume is disabled and file is
-     transfered from begin!}
+     transferred from begin!}
     function StoreFile(const FileName: string; Restore: Boolean): Boolean; virtual;
 
-    {:Send data to FTP server and assing unique name for this file.}
+    {:Send data to FTP server and assign unique name for this file.}
     function StoreUniqueFile: Boolean; virtual;
 
     {:Append data to FileName on FTP server.}
@@ -336,7 +336,7 @@ type
      timeout.}
     function NoOp: Boolean; virtual;
 
-    {:Change currect working directory to Directory on FTP server.}
+    {:Change current working directory to Directory on FTP server.}
     function ChangeWorkingDir(const Directory: string): Boolean; virtual;
 
     {:walk to upper directory on FTP server.}
@@ -390,14 +390,14 @@ type
 
     {:Type of Firewall. Used only if you set some firewall address. Supported
      predefined firewall login sequences are described by comments in source
-     file where you can see pseudocode decribing each sequence.}
+     file where you can see pseudocode describing each sequence.}
     property FWMode: integer read FFWMode Write FFWMode;
 
     {:Socket object used for TCP/IP operation on control channel. Good for
-     seting OnStatus hook, etc.}
+     setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
 
-    {:Socket object used for TCP/IP operation on data channel. Good for seting
+    {:Socket object used for TCP/IP operation on data channel. Good for setting
      OnStatus hook, etc.}
     property DSock: TTCPBlockSocket read FDSock;
 
@@ -416,7 +416,7 @@ type
     {:Mode of data handling by data connection. If @False, all data operations
      are made to or from @link(DataStream) TMemoryStream.
      If @true, data operations is made directly to file in your disk. (filename
-     is specified by @link(DirectFileName) property.) Dafault is @False!}
+     is specified by @link(DirectFileName) property.) Default is @False!}
     property DirectFile: Boolean read FDirectFile Write FDirectFile;
 
     {:Filename for direct disk data operations.}
@@ -471,7 +471,7 @@ type
   end;
 
 {:A very useful function, and example of use can be found in the TFtpSend object.
- Dowload specified file from FTP server to LocalFile.}
+ Download specified file from FTP server to LocalFile.}
 function FtpGetFile(const IP, Port, FileName, LocalFile,
   User, Pass: string): Boolean;
 
@@ -905,7 +905,7 @@ begin
       s := cFtpDataProtocol
     else
       s := '0';
-    //data conection from same interface as command connection
+    //data connection from same interface as command connection
     FDSock.Bind(FSock.GetLocalSinIP, s);
     if FDSock.LastError <> 0 then
       Exit;
@@ -1335,7 +1335,7 @@ begin
   FMasks.add('       dxx                                              n*');     //Fiala
   //VMS - new untouched files (name only)
   //          ADR10AI2
-  FMasks.Add('n*§');                                                            //Fiala
+  FMasks.Add('n*ï¿½');                                                            //Fiala
   //IBM VM
   //          MQ_REPTS TESTVIEW V         72        139          1 2009-01-28 11:58:07 -
   //          NEW               DIR        -          -          - 2009-11-04 18:31:50 -
@@ -1438,7 +1438,7 @@ begin
   Value := TrimRight(Value);                                                    //Fiala
   while Imask <= Length(mask) do
   begin
-    if not (Mask[Imask] in ['*', '\', '§']) and (Ivalue > Length(Value)) then   //Fiala
+    if not (Mask[Imask] in ['*', '\', 'ï¿½']) and (Ivalue > Length(Value)) then   //Fiala
     begin
       Result := 0;
       Exit;
@@ -1546,7 +1546,7 @@ begin
           end;
           Dec(IValue);
         end;
-      '§':                                                                      //Fiala
+      'ï¿½':                                                                      //Fiala
         if IValue < Length(Value) then
         begin
           Result := 0;

--- a/component/synapse/ftptsend.pas
+++ b/component/synapse/ftptsend.pas
@@ -100,7 +100,7 @@ type
     function RecvFile(const Filename: string): Boolean;
 
     {:Acts as TFTP server and wait for client request. When some request
-     incoming within Timeout, result is @true and parametres is filled with
+     incoming within Timeout, result is @true and parameters is filled with
      information from request. You must handle this request, validate it, and
      call @link(ReplyError), @link(ReplyRecv) or @link(ReplySend) for send reply
      to TFTP Client.}
@@ -120,10 +120,10 @@ type
     {:Code of TFTP error.}
     property ErrorCode: integer read FErrorCode;
 
-    {:Human readable decription of TFTP error. (if is sended by remote side)}
+    {:Human readable description of TFTP error. (if it is sent by remote side)}
     property ErrorString: string read FErrorString;
 
-    {:MemoryStream with datas for sending or receiving}
+    {:MemoryStream with data for sending or receiving}
     property Data: TMemoryStream read FData;
 
     {:Address of TFTP remote side.}

--- a/component/synapse/httpsend.pas
+++ b/component/synapse/httpsend.pas
@@ -232,13 +232,13 @@ type
     property Sock: TTCPBlockSocket read FSock;
 
     {:Allows to switch off port number in 'Host:' HTTP header. By default @TRUE.
-     Some buggy servers do not like port informations in this header.}
+     Some buggy servers do not like port information in this header.}
     property AddPortNumberToHost: Boolean read FAddPortNumberToHost write FAddPortNumberToHost;
   public
-    {:for direct sending from any TStream. Defalut nil = use Document property instead.}
+    {:for direct sending from any TStream. Default nil = use Document property instead.}
     property InputStream: TStream read FInputStream write FInputStream;
 
-    {:for direct dovnloading into any TStream. Defalut nil = use Document property instead.}
+    {:for direct dovnloading into any TStream. Default nil = use Document property instead.}
     property OutputStream: TStream read FOutputStream write FOutputStream;
   end;
 
@@ -393,7 +393,7 @@ begin
     if (FSock.SSL.SNIHost='') then
       FSock.SSL.SNIHost:=FTargetHost;
     FSock.SSLDoConnect;
-    FSock.SSL.SNIHost:=''; //don't need it anymore and don't wan't to reuse it in next connection
+    FSock.SSL.SNIHost:=''; //don't need it anymore and don't want to reuse it in next connection
     if FSock.LastError <> 0 then
       Exit;
   end;

--- a/component/synapse/imapsend.pas
+++ b/component/synapse/imapsend.pas
@@ -183,7 +183,7 @@ type
     function AppendMess(ToFolder: string; const Mess: TStrings): Boolean;
 
     {:'Delete' message from current selected folder. It mark message as Deleted.
-     Real deleting will be done after sucessfull @link(CloseFolder) or
+     Real deleting will be done after successful @link(CloseFolder) or
      @link(ExpungeFolder)}
     function DeleteMess(MessID: integer): boolean;
 
@@ -222,7 +222,7 @@ type
     {:return UID of requested message ID.}
     function GetUID(MessID: integer; var UID : Integer): Boolean;
 
-    {:Try to find given capabily in capabilty string returned from IMAP server.}
+    {:Try to find given capabily in capability string returned from IMAP server.}
     function FindCap(const Value: string): string;
   published
     {:Status line with result of last operation.}
@@ -231,7 +231,7 @@ type
     {:Full result of last IMAP operation.}
     property FullResult: TStringList read FFullResult;
 
-    {:List of server capabilites.}
+    {:List of server capabilities.}
     property IMAPcap: TStringList read FIMAPcap;
 
     {:Authorization is successful done.}
@@ -259,10 +259,10 @@ type
     property AutoTLS: Boolean read FAutoTLS Write FAutoTLS;
 
     {:SSL/TLS mode is used from first contact to server. Servers with full
-     SSL/TLS mode usualy using non-standard TCP port!}
+     SSL/TLS mode usually using non-standard TCP port!}
     property FullSSL: Boolean read FFullSSL Write FFullSSL;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
   end;
 

--- a/component/synapse/jedi.inc
+++ b/component/synapse/jedi.inc
@@ -80,7 +80,7 @@
   CLR                 Defined when target platform is .NET
 
 - Architecture directives. These are auto-defined by FPC
-  CPU32 and CPU64 are mostly for generic pointer size dependant differences rather
+  CPU32 and CPU64 are mostly for generic pointer size dependent differences rather
   than for a specific architecture.
 
   CPU386              Defined when target platform is native x86 (win32)
@@ -405,7 +405,7 @@
 
   The following directives are direct mappings from the VERXXX directives to a
   friendly name of the associated compiler. Unlike the DELPHI_X and BCB_X
-  directives, these directives are indepedent of the development environment.
+  directives, these directives are independent of the development environment.
   That is, they are defined regardless of whether compilation takes place using
   Delphi or C++Builder.
 
@@ -519,11 +519,11 @@
   Directive     Description
   ------------------------------------------------------------------------------
   CLR            Defined when compiling for .NET
-  CLR10          Defined when compiling for .NET 1.0 (may be overriden by FORCE_CLR10)
+  CLR10          Defined when compiling for .NET 1.0 (may be overridden by FORCE_CLR10)
   CLR10_UP       Defined when compiling for .NET 1.0 or higher
-  CLR11          Defined when compiling for .NET 1.1 (may be overriden by FORCE_CLR11)
+  CLR11          Defined when compiling for .NET 1.1 (may be overridden by FORCE_CLR11)
   CLR11_UP       Defined when compiling for .NET 1.1 or higher
-  CLR20          Defined when compiling for .NET 2.0 (may be overriden by FORCE_CLR20)
+  CLR20          Defined when compiling for .NET 2.0 (may be overridden by FORCE_CLR20)
   CLR20_UP       Defined when compiling for .NET 2.0 or higher
 
 
@@ -573,7 +573,7 @@
   SUPPORTS_CLASS_FIELDS          Compiler supports class fields (D9.NET, D10+)
   SUPPORTS_CLASS_HELPERS         Compiler supports class helpers (D9.NET, D10+)
   SUPPORTS_CLASS_OPERATORS       Compiler supports class operators (D9.NET, D10+)
-  SUPPORTS_CLASS_CTORDTORS       Compiler supports class contructors/destructors (D14+)
+  SUPPORTS_CLASS_CTORDTORS       Compiler supports class constructors/destructors (D14+)
   SUPPORTS_STRICT                Compiler supports strict keyword (D9.NET, D10+)
   SUPPORTS_STATIC                Compiler supports static keyword (D9.NET, D10+)
   SUPPORTS_FINAL                 Compiler supports final keyword (D9.NET, D10+)
@@ -625,7 +625,7 @@
   HAS_ENOTIMPLEMENTED            Exception class ENotImplemented is available (D15+)
   HAS_UNIT_VCL_THEMES            Unit Vcl.Themes is available (D16+)
   HAS_UNIT_UXTHEME               Unit (Vcl.)UxTheme is available (D7+)
-  HAS_EXCEPTION_STACKTRACE       Exception class has the StackTrace propery (D12+)
+  HAS_EXCEPTION_STACKTRACE       Exception class has the StackTrace property (D12+)
   SUPPORTS_LEGACYIFEND           Compiler supports the LEGACYIFEND directive (D17+)
   DEPRECATED_TCHARACTER          TCharacter is deprecated and replaced by a record helper on Char (D18+)
   HAS_PROPERTY_OLDCREATEORDER    The OldCreateOrder property is available (D5 - D27)
@@ -635,7 +635,7 @@
 
   The compiler settings directives indicate whether a specific compiler setting
   is in effect. This facilitates changing compiler settings locally in a more
-  compact and readible manner.
+  compact and readable manner.
 
   Directive              Description
   ------------------------------------------------------------------------------
@@ -652,7 +652,7 @@
   TYPEINFO_ON            Compiling in the M+ state (RTTI generation on)
   OPTIMIZATION_ON        Compiling in the O+ state (code optimization on)
   OPENSTRINGS_ON         Compiling in the P+ state (variable string parameters are openstrings)
-  OVERFLOWCHECKS_ON      Compiling in the Q+ state (overflow checing on)
+  OVERFLOWCHECKS_ON      Compiling in the Q+ state (overflow checking on)
   RANGECHECKS_ON         Compiling in the R+ state (range checking on)
   TYPEDADDRESS_ON        Compiling in the T+ state (pointers obtained using the @ operator are typed)
   SAFEDIVIDE_ON          Compiling in the U+ state (save FDIV instruction through RTL emulation)

--- a/component/synapse/kylix.inc
+++ b/component/synapse/kylix.inc
@@ -3,7 +3,7 @@
 //
 // Kylix 3/C++ for some reason evaluates CompilerVersion comparisons to False,
 // if the constant to compare with is a floating point value - weird.
-// The "+" sign prevents Kylix/Delphi from issueing a warning about comparing
+// The "+" sign prevents Kylix/Delphi from issuing a warning about comparing
 // signed and unsigned values.
 //
     {$IF not Declared(CompilerVersion)}

--- a/component/synapse/ldapsend.pas
+++ b/component/synapse/ldapsend.pas
@@ -241,16 +241,16 @@ type
     function Login: Boolean;
 
     {:Try to bind to LDAP server with @link(TSynaClient.Username) and
-     @link(TSynaClient.Password). If this is empty strings, then it do annonymous
-     Bind. When you not call Bind on LDAPv3, then is automaticly used anonymous
+     @link(TSynaClient.Password). If this is empty strings, then it do anonymous
+     Bind. When you not call Bind on LDAPv3, then is automatically used anonymous
      mode.
 
      This method using plaintext transport of password! It is not secure!}
     function Bind: Boolean;
 
     {:Try to bind to LDAP server with @link(TSynaClient.Username) and
-     @link(TSynaClient.Password). If this is empty strings, then it do annonymous
-     Bind. When you not call Bind on LDAPv3, then is automaticly used anonymous
+     @link(TSynaClient.Password). If this is empty strings, then it do anonymous
+     Bind. When you not call Bind on LDAPv3, then is automatically used anonymous
      mode.
 
      This method using SASL with DIGEST-MD5 method for secure transfer of your
@@ -331,9 +331,9 @@ type
     {:Here is result of search command.}
     property SearchResult: TLDAPResultList read FSearchResult;
 
-    {:On each LDAP operation can LDAP server return some referals URLs. Here is
+    {:On each LDAP operation can LDAP server return some referrals URLs. Here is
      their list.}
-    property Referals: TStringList read FReferals;
+    property Referrals: TStringList read FReferals;
 
     {:When you call @link(Extended) operation, then here is result Name returned
      by server.}
@@ -696,7 +696,7 @@ begin
   //get length of LDAP packet
   j := 2;
   i := ASNDecLen(j, Result);
-  //retreive rest of LDAP packet
+  //retrieve rest of LDAP packet
   if i > 0 then
     Result := Result + FSock.RecvBufferStr(i, Ftimeout);
   if FSock.LastError <> 0 then

--- a/component/synapse/mimemess.pas
+++ b/component/synapse/mimemess.pas
@@ -104,7 +104,7 @@ type
      This is good for reading any non-parsed header.}
     function FindHeader(Value: string): string;
 
-    {:Try find specific headers in CustomHeader. This metod is for repeatly used
+    {:Try find specific headers in CustomHeader. This method is for repeatedly used
      headers like 'received' header, etc. Search is case insensitive.
      This is good for reading ano non-parsed header.}
     procedure FindHeaderList(Value: string; const HeaderList: TStrings);
@@ -125,7 +125,7 @@ type
     property Organization: string read FOrganization Write FOrganization;
 
     {:After decoding contains all headers lines witch not have parsed to any
-     other structures in this object. It mean: this conatins all other headers
+     other structures in this object. It mean: this contains all other headers
      except:
 
      X-MAILER, FROM, SUBJECT, ORGANIZATION, TO, CC, DATE, MIME-VERSION,
@@ -133,7 +133,7 @@ type
      CONTENT-TRANSFER-ENCODING, REPLY-TO, MESSAGE-ID, X-MSMAIL-PRIORITY,
      X-PRIORITY, PRIORITY
 
-     When you encode headers, all this lines is added as headers. Be carefull
+     When you encode headers, all this lines is added as headers. Be careful
      for duplicites!}
     property CustomHeaders: TStringList read FCustomHeaders;
 
@@ -196,7 +196,7 @@ type
      must have PartParent of multipart type!
 
      After creation of part set type to text part and set all necessary
-     properties. Content of part is readed from value stringlist.}
+     properties. Content of part is read from value stringlist.}
     function AddPartText(const Value: TStrings; const PartParent: TMimePart): TMimepart;
 
     {:Add MIME part as subpart of PartParent. If you need set root MIME part,
@@ -204,7 +204,7 @@ type
      must have PartParent of multipart type!
 
      After creation of part set type to text part and set all necessary
-     properties. Content of part is readed from value stringlist. You can select
+     properties. Content of part is read from value stringlist. You can select
      your charset and your encoding type. If Raw is @true, then it not doing
      charset conversion!}
     function AddPartTextEx(const Value: TStrings; const PartParent: TMimePart;
@@ -215,13 +215,13 @@ type
      must have PartParent of multipart type!
 
      After creation of part set type to text part to HTML type and set all
-     necessary properties. Content of HTML part is readed from Value stringlist.}
+     necessary properties. Content of HTML part is read from Value stringlist.}
     function AddPartHTML(const Value: TStrings; const PartParent: TMimePart): TMimepart;
 
-    {:Same as @link(AddPartText), but content is readed from file}
+    {:Same as @link(AddPartText), but content is read from file}
     function AddPartTextFromFile(const FileName: String; const PartParent: TMimePart): TMimepart;
 
-    {:Same as @link(AddPartHTML), but content is readed from file}
+    {:Same as @link(AddPartHTML), but content is read from file}
     function AddPartHTMLFromFile(const FileName: String; const PartParent: TMimePart): TMimepart;
 
     {:Add MIME part as subpart of PartParent. If you need set root MIME part,
@@ -229,12 +229,12 @@ type
      you must have PartParent of multipart type!
 
      After creation of part set type to binary and set all necessary properties.
-     MIME primary and secondary types defined automaticly by filename extension.
-     Content of binary part is readed from Stream. This binary part is encoded
+     MIME primary and secondary types defined automatically by filename extension.
+     Content of binary part is read from Stream. This binary part is encoded
      as file attachment.}
     function AddPartBinary(const Stream: TStream; const FileName: string; const PartParent: TMimePart): TMimepart;
 
-    {:Same as @link(AddPartBinary), but content is readed from file}
+    {:Same as @link(AddPartBinary), but content is read from file}
     function AddPartBinaryFromFile(const FileName: string; const PartParent: TMimePart): TMimepart;
 
     {:Add MIME part as subpart of PartParent. If you need set root MIME part,
@@ -242,14 +242,14 @@ type
      must have PartParent of multipart type!
 
      After creation of part set type to binary and set all necessary properties.
-     MIME primary and secondary types defined automaticly by filename extension.
-     Content of binary part is readed from Stream.
+     MIME primary and secondary types defined automatically by filename extension.
+     Content of binary part is read from Stream.
 
-     This binary part is encoded as inline data with given Conten ID (cid).
+     This binary part is encoded as inline data with given Contain ID (cid).
      Content ID can be used as reference ID in HTML source in HTML part.}
     function AddPartHTMLBinary(const Stream: TStream; const FileName, Cid: string; const PartParent: TMimePart): TMimepart;
 
-    {:Same as @link(AddPartHTMLBinary), but content is readed from file}
+    {:Same as @link(AddPartHTMLBinary), but content is read from file}
     function AddPartHTMLBinaryFromFile(const FileName, Cid: string; const PartParent: TMimePart): TMimepart;
 
     {:Add MIME part as subpart of PartParent. If you need set root MIME part,
@@ -257,11 +257,11 @@ type
      must have PartParent of multipart type!
 
      After creation of part set type to message and set all necessary properties.
-     MIME primary and secondary types are setted to 'message/rfc822'.
-     Content of raw RFC-822 message is readed from Stream.}
+     MIME primary and secondary types are set to 'message/rfc822'.
+     Content of raw RFC-822 message is read from Stream.}
     function AddPartMess(const Value: TStrings; const PartParent: TMimePart): TMimepart;
 
-    {:Same as @link(AddPartMess), but content is readed from file}
+    {:Same as @link(AddPartMess), but content is read from file}
     function AddPartMessFromFile(const FileName: string; const PartParent: TMimePart): TMimepart;
 
     {:Compose message from @link(MessagePart) to @link(Lines). Headers from
@@ -280,7 +280,7 @@ type
      On the top of it, HTTP connections are always 8-bit, hence data are
      transferred in native format i.e. no transfer encoding is applied.
 
-     This method operates the similiar way and produces the same
+     This method operates the similar way and produces the same
      result as @link(DecodeMessage).
     }
     procedure DecodeMessageBinary(AHeader:TStrings; AData:TMemoryStream);
@@ -294,7 +294,7 @@ type
     {:Raw MIME encoded message.}
     property Lines: TStringList read FLines;
 
-    {:Object for e-mail header fields. This object is created automaticly.
+    {:Object for e-mail header fields. This object is created automatically.
      Do not free this object!}
     property Header: TMessHeader read FHeader;
   end;

--- a/component/synapse/mimepart.pas
+++ b/component/synapse/mimepart.pas
@@ -193,7 +193,7 @@ type
 
     {:E-mail message in @link(Lines) property is parsed into this object.
      E-mail headers are stored in @link(Headers) property and is parsed into
-     another properties automaticly. Not need call @link(DecodePartHeader)!
+     another properties automatically. Not need call @link(DecodePartHeader)!
      Content of message (part) is stored into @link(PartBody) property. This
      part is in undecoded form! If you need decode it, then you must call
      @link(DecodePart) method by your hands. Lot of another properties is filled
@@ -214,7 +214,7 @@ type
      On the top of it, HTTP connections are always 8-bit, hence data are
      transferred in native format i.e. no transfer encoding is applied.
 
-     This method operates the similiar way and produces the same
+     This method operates the similar way and produces the same
      result as @link(DecomposeParts).
     }
     procedure DecomposePartsBinary(AHeader:TStrings; AStx,AEtx:PANSIChar);
@@ -234,15 +234,15 @@ type
     function CanSubPart: boolean;
   published
     {:Primary Mime type of part. (i.e. 'application') Writing to this property
-     automaticly generate value of @link(PrimaryCode).}
+     automatically generate value of @link(PrimaryCode).}
     property Primary: string read FPrimary write SetPrimary;
 
     {:String representation of used Mime encoding in part. (i.e. 'base64')
-     Writing to this property automaticly generate value of @link(EncodingCode).}
+     Writing to this property automatically generate value of @link(EncodingCode).}
     property Encoding: string read FEncoding write SetEncoding;
 
     {:String representation of used Mime charset in part. (i.e. 'iso-8859-1')
-     Writing to this property automaticly generate value of @link(CharsetCode).
+     Writing to this property automatically generate value of @link(CharsetCode).
      Charset is used only for text parts.}
     property Charset: string read FCharset write SetCharset;
 
@@ -273,7 +273,7 @@ type
      and @link(TargetCharset)}
     property ConvertCharset: Boolean read FConvertCharset Write FConvertCharset;
 
-    {:If @true, then allways do internal charset translation of HTML parts
+    {:If @true, then always do internal charset translation of HTML parts
      by MIME even it have their own charset in META tag. Default is @false.}
     property ForcedHTMLConvert: Boolean read FForcedHTMLConvert Write FForcedHTMLConvert;
 
@@ -331,7 +331,7 @@ type
     property OnWalkPart: THookWalkPart read FOnWalkPart write FOnWalkPart;
 
     {:Here you can specify maximum line length for encoding of MIME part.
-     If line is longer, then is splitted by standard of MIME. Correct MIME
+     If line is longer, then is split by standard of MIME. Correct MIME
      mailers can de-split this line into original length.}
     property MaxLineLength: integer read FMaxLineLength Write FMaxLineLength;
   end;
@@ -823,7 +823,7 @@ begin
   FDecodedLines.Clear;
   {pf}
   // The part decomposer passes data via TStringList which appends trailing line
-  // break inherently. But in a case of native 8-bit data transferred withouth
+  // break inherently. But in a case of native 8-bit data transferred without
   // encoding (default e.g. for HTTP protocol), the redundant line terminators
   // has to be removed
   if FBinaryDecomposer and (FPartBody.Count=1) then

--- a/component/synapse/nntpsend.pas
+++ b/component/synapse/nntpsend.pas
@@ -133,7 +133,7 @@ type
     {:Select given group.}
     function SelectGroup(const Value: string): Boolean;
 
-    {:Tell to server 'I have mesage with given message-ID.' If server need this
+    {:Tell to server 'I have message with given message-ID.' If server need this
      message, message is uploaded to server.}
     function IHave(const MessID: string): Boolean;
 
@@ -180,7 +180,7 @@ type
     {:String description of last result code from NNTP server.}
     property ResultString: string read FResultString;
 
-    {:Readed data. (message, etc.)}
+    {:Read data. (message, etc.)}
     property Data: TStringList read FData;
 
     {:If is set to @true, then upgrade to SSL/TLS mode after login if remote
@@ -188,10 +188,10 @@ type
     property AutoTLS: Boolean read FAutoTLS Write FAutoTLS;
 
     {:SSL/TLS mode is used from first contact to server. Servers with full
-     SSL/TLS mode usualy using non-standard TCP port!}
+     SSL/TLS mode usually using non-standard TCP port!}
     property FullSSL: Boolean read FFullSSL Write FFullSSL;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
   end;
 

--- a/component/synapse/pingsend.pas
+++ b/component/synapse/pingsend.pas
@@ -49,7 +49,7 @@ This unit using IpHlpApi (on WinXP or higher) if available. Otherwise it trying
  to use RAW sockets.
 
 Warning: For use of RAW sockets you must have some special rights on some
- systems. So, it working allways when you have administator/root rights.
+ systems. So, it working always when you have administrator/root rights.
  Otherwise you can have problems!
 
 Note: This unit is NOT portable to .NET!
@@ -155,8 +155,8 @@ type
     {:Time between request and reply.}
     property PingTime: Integer read FPingTime;
 
-    {:From this address is sended reply for your PING request. It maybe not your
-     requested destination, when some error occured!}
+    {:From this address is sent reply for your PING request. It maybe not your
+     requested destination, when some error occurred!}
     property ReplyFrom: string read FReplyFrom;
 
     {:ICMP type of PING reply. Each protocol using another values! For IPv4 and
@@ -175,7 +175,7 @@ type
     {:Return human readable description of returned packet type.}
     property ReplyErrorDesc: string read FReplyErrorDesc;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TICMPBlockSocket read FSock;
 
     {:TTL value for ICMP query}
@@ -432,7 +432,7 @@ begin
       t := false;
       Break;
     end;
-  //it discard sometimes possible 'echoes' of previosly sended packet
+  //it discard sometimes possible 'echoes' of previously sent packet
   //or other unwanted ICMP packets...
   until (IcmpEchoHeaderPtr^.i_type <> FIcmpEcho)
     and ((IcmpEchoHeaderPtr^.i_id = FId)

--- a/component/synapse/pop3send.pas
+++ b/component/synapse/pop3send.pas
@@ -106,10 +106,10 @@ type
 
     {:You can call any custom by this method. Call Command without trailing CRLF.
       If MultiLine parameter is @true, multilined response are expected.
-      Result is @true on sucess.}
+      Result is @true on success.}
     function CustomCommand(const Command: string; MultiLine: Boolean): boolean;
 
-    {:Call CAPA command for get POP3 server capabilites.
+    {:Call CAPA command for get POP3 server capabilities.
      note: not all servers support this command!}
     function Capability: Boolean;
 
@@ -133,18 +133,18 @@ type
      successful operation is listing in FullResult. If all OK, result is @True.}
     function List(Value: Integer): Boolean;
 
-    {:Send RETR command. After successful operation dowloaded message in
+    {:Send RETR command. After successful operation downloaded message in
      @link(FullResult). If all OK, result is @true.}
     function Retr(Value: Integer): Boolean;
 
-    {:Send RETR command. After successful operation dowloaded message in
+    {:Send RETR command. After successful operation downloaded message in
      @link(Stream). If all OK, result is @true.}
     function RetrStream(Value: Integer; Stream: TStream): Boolean;
 
     {:Send DELE command for delete specified message. If all OK, result is @true.}
     function Dele(Value: Integer): Boolean;
 
-    {:Send TOP command. After successful operation dowloaded headers of message
+    {:Send TOP command. After successful operation downloaded headers of message
      and maxlines count of message in @link(FullResult). If all OK, result is
      @true.}
     function Top(Value, Maxlines: Integer): Boolean;
@@ -156,7 +156,7 @@ type
     {:Call STLS command for upgrade connection to SSL/TLS mode.}
     function StartTLS: Boolean;
 
-    {:Try to find given capabily in capabilty string returned from POP3 server
+    {:Try to find given capabily in capability string returned from POP3 server
      by CAPA command.}
     function FindCap(const Value: string): string;
   published
@@ -184,7 +184,7 @@ type
      remote server.}
     property TimeStamp: string read FTimeStamp;
 
-    {:Type of authorisation for login to POP3 server. Dafault is autodetect one
+    {:Type of authorisation for login to POP3 server. Default is autodetect one
      of possible authorisation. Autodetect do this:
 
      If remote POP3 server support APOP, try login by APOP method. If APOP is
@@ -195,9 +195,9 @@ type
     property AutoTLS: Boolean read FAutoTLS Write FAutoTLS;
 
     {:SSL/TLS mode is used from first contact to server. Servers with full
-     SSL/TLS mode usualy using non-standard TCP port!}
+     SSL/TLS mode usually using non-standard TCP port!}
     property FullSSL: Boolean read FFullSSL Write FFullSSL;
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
   end;
 

--- a/component/synapse/smtpsend.pas
+++ b/component/synapse/smtpsend.pas
@@ -70,7 +70,7 @@ const
   cSmtpProtocol = '25';
 
 type
-  {:@abstract(Implementation of SMTP and ESMTP procotol),
+  {:@abstract(Implementation of SMTP and ESMTP protocol),
    include some ESMTP extensions, include SSL/TLS too.
 
    Note: Are you missing properties for setting Username and Password for ESMTP?
@@ -109,8 +109,8 @@ type
 
     {:Connects to SMTP server (defined in @link(TSynaClient.TargetHost)) and
      begin SMTP session. (First try ESMTP EHLO, next old HELO handshake). Parses
-     ESMTP capabilites and if you specified Username and password and remote
-     server can handle AUTH command, try login by AUTH command. Preffered login
+     ESMTP capabilities and if you specified Username and password and remote
+     server can handle AUTH command, try login by AUTH command. Preferred login
      method is CRAM-MD5 (if safer!). If all OK, result is @true, else result is
      @false.}
     function Login: Boolean;
@@ -127,7 +127,7 @@ type
     function NoOp: Boolean;
 
     {:Send MAIL FROM SMTP command for set sender e-mail address. If sender's
-     e-mail address is empty string, transmited message is error message.
+     e-mail address is empty string, transmitted message is error message.
 
      If size not 0 and remote server can handle SIZE parameter, append SIZE
      parameter to request. If all OK, result is @true, else result is @false.}
@@ -169,14 +169,14 @@ type
     {:All result strings of last SMTP command (result is maybe multiline!).}
     property FullResult: TStringList read FFullResult;
 
-    {:List of ESMTP capabilites of remote ESMTP server. (If you connect to ESMTP
+    {:List of ESMTP capabilities of remote ESMTP server. (If you connect to ESMTP
      server only!).}
     property ESMTPcap: TStringList read FESMTPcap;
 
-    {:@TRUE if you successfuly logged to ESMTP server.}
+    {:@TRUE if you successfully logged to ESMTP server.}
     property ESMTP: Boolean read FESMTP;
 
-    {:@TRUE if you successfuly pass authorisation to remote server.}
+    {:@TRUE if you successfully pass authorisation to remote server.}
     property AuthDone: Boolean read FAuthDone;
 
     {:@TRUE if remote server can handle SIZE parameter.}
@@ -206,10 +206,10 @@ type
     property AutoTLS: Boolean read FAutoTLS Write FAutoTLS;
 
     {:SSL/TLS mode is used from first contact to server. Servers with full
-     SSL/TLS mode usualy using non-standard TCP port!}
+     SSL/TLS mode usually using non-standard TCP port!}
     property FullSSL: Boolean read FFullSSL Write FFullSSL;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
   end;
 

--- a/component/synapse/snmpsend.pas
+++ b/component/synapse/snmpsend.pas
@@ -155,7 +155,7 @@ type
     property Value: AnsiString read FValue write FValue;
 
     {:Define type of Value. Supported values are defined in @link(asn1util).
-     For queries use ASN1_NULL, becouse you don't know type in response!}
+     For queries use ASN1_NULL, because you don't know type in response!}
     property ValueType: Integer read FValueType write FValueType;
   end;
 
@@ -217,7 +217,7 @@ type
     {:Decode SNMP packet in buffer to object properties.}
     function DecodeBuf(Buffer: AnsiString): Boolean;
 
-    {:Encode obeject properties to SNMP packet.}
+    {:Encode object properties to SNMP packet.}
     function EncodeBuf: AnsiString;
 
     {:Clears all object properties to default values.}
@@ -246,7 +246,7 @@ type
      value 1 for SNMPv2c or value 3 for SNMPv3.}
     property Version: Integer read FVersion write FVersion;
 
-    {:Community string for autorize access to SNMP server. (Case sensitive!)
+    {:Community string for authorize access to SNMP server. (Case sensitive!)
      Community string is not used in SNMPv3! Use @link(Username) and
      @link(password) instead!}
     property Community: AnsiString read FCommunity write FCommunity;
@@ -261,7 +261,7 @@ type
      E* constants.}
     property ErrorStatus: Integer read FErrorStatus write FErrorStatus;
 
-    {:Point to error position in reply packet. Not usefull for users. It only
+    {:Point to error position in reply packet. Not useful for users. It only
      good for debugging!}
     property ErrorIndex: Integer read FErrorIndex write FErrorIndex;
 
@@ -384,7 +384,7 @@ type
     {:Data object contains SNMP reply.}
     property Reply: TSNMPRec read FReply;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TUDPBlockSocket read FSock;
   end;
 
@@ -414,10 +414,10 @@ function SNMPGetNext(var OID: AnsiString; const Community, SNMPHost: AnsiString;
  object. It implements basic read of SNMP MIB tables. As BaseOID you must
  specify basic MIB OID of requested table (base IOD is OID without row and
  column specificator!)
- Table is readed into stringlist, where each string is comma delimited string.
+ Table is read into stringlist, where each string is comma delimited string.
 
  Warning: this function is not have best performance. For better performance
- you must write your own function. best performace you can get by knowledge
+ you must write your own function. best performance you can get by knowledge
  of structuture of table and by more then one MIB on one query. }
 function SNMPGetTable(const BaseOID, Community, SNMPHost: AnsiString; const Value: TStrings): Boolean;
 

--- a/component/synapse/sntpsend.pas
+++ b/component/synapse/sntpsend.pas
@@ -154,12 +154,12 @@ type
      changed!}
     property MaxSyncDiff: double read FMaxSyncDiff write FMaxSyncDiff;
 
-    {:If @true, after successfull getting time is local computer clock
+    {:If @true, after successful getting time is local computer clock
      synchronised to given time.
      For synchronising time you must have proper rights! (Usually Administrator)}
     property SyncTime: Boolean read FSyncTime write FSyncTime;
 
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TUDPBlockSocket read FSock;
   end;
 

--- a/component/synapse/ssfpc.inc
+++ b/component/synapse/ssfpc.inc
@@ -49,7 +49,7 @@
 
 //{$DEFINE FORCEOLDAPI}
 {Note about define FORCEOLDAPI:
-If you activate this compiler directive, then is allways used old socket API
+If you activate this compiler directive, then is always used old socket API
 for name resolution. If you leave this directive inactive, then the new API
 is used, when running system allows it.
 

--- a/component/synapse/ssl_cryptlib.pas
+++ b/component/synapse/ssl_cryptlib.pas
@@ -45,7 +45,7 @@
 {:@abstract(SSL/SSH plugin for CryptLib)
 
 This plugin requires cl32.dll at least version 3.2.0! It can be used on Win32
-and Linux. This library is staticly linked - when you compile your application
+and Linux. This library is statically linked - when you compile your application
 with this plugin, you MUST distribute it with Cryptib library, otherwise you
 cannot run your application!
 
@@ -65,7 +65,7 @@ with non-matching certificates will be rejected by cryptLib.
 
 This plugin is capable to create Ad-Hoc certificates. When you start SSL/TLS
 server without explicitly assigned key and certificate, then this plugin create
-Ad-Hoc key and certificate for each incomming connection by self. It slowdown
+Ad-Hoc key and certificate for each incoming connection by self. It slowdown
 accepting of new connections!
 
 You can use this plugin for SSHv2 connections too! You must explicitly set

--- a/component/synapse/ssl_openssl.pas
+++ b/component/synapse/ssl_openssl.pas
@@ -53,7 +53,7 @@ Compatibility with OpenSSL versions:
 0.9.7 - 1.0.0 working fine.
 1.1.0 should work, under testing.
 
-OpenSSL libraries are loaded dynamicly - you not need OpenSSL librares even you
+OpenSSL libraries are loaded dynamically - you not need OpenSSL librares even you
 compile your application with this unit. SSL just not working when you not have
 OpenSSL libraries.
 
@@ -73,7 +73,7 @@ For handling keys and certificates you can use this properties:
 
 This plugin is capable to create Ad-Hoc certificates. When you start SSL/TLS
 server without explicitly assigned key and certificate, then this plugin create
-Ad-Hoc key and certificate for each incomming connection by self. It slowdown
+Ad-Hoc key and certificate for each incoming connection by self. It slowdown
 accepting of new connections!
 }
 

--- a/component/synapse/ssl_openssl11.pas
+++ b/component/synapse/ssl_openssl11.pas
@@ -51,7 +51,7 @@ Compatibility with OpenSSL versions:
 1.1.0
 1.1.1
 
-OpenSSL libraries are loaded dynamicly - you not need OpenSSL librares even you
+OpenSSL libraries are loaded dynamically - you not need OpenSSL librares even you
 compile your application with this unit. SSL just not working when you not have
 OpenSSL libraries.
 
@@ -69,7 +69,7 @@ For handling keys and certificates you can use this properties:
 
 This plugin is capable to create Ad-Hoc certificates. When you start SSL/TLS
 server without explicitly assigned key and certificate, then this plugin create
-Ad-Hoc key and certificate for each incomming connection by self. It slowdown
+Ad-Hoc key and certificate for each incoming connection by self. It slowdown
 accepting of new connections!
 }
 

--- a/component/synapse/ssl_openssl11_lib.pas
+++ b/component/synapse/ssl_openssl11_lib.pas
@@ -72,7 +72,7 @@ Special thanks to Gregor Ibic <gregor.ibic@intelicom.si>
 {:@abstract(OpenSSL support)
 
 This unit is Pascal interface to OpenSSL library (used by @link(ssl_openssl) unit).
-OpenSSL 1.1 is loaded dynamicly on-demand. If this library is not found in system,
+OpenSSL 1.1 is loaded dynamically on-demand. If this library is not found in system,
 requested OpenSSL function just return errorcode.
 }
 unit ssl_openssl11_lib;

--- a/component/synapse/ssl_openssl_lib.pas
+++ b/component/synapse/ssl_openssl_lib.pas
@@ -74,7 +74,7 @@ Special thanks to Gregor Ibic <gregor.ibic@intelicom.si>
 {:@abstract(OpenSSL support)
 
 This unit is Pascal interface to OpenSSL library (used by @link(ssl_openssl) unit).
-OpenSSL is loaded dynamicly on-demand. If this library is not found in system,
+OpenSSL is loaded dynamically on-demand. If this library is not found in system,
 requested OpenSSL function just return errorcode.
 }
 unit ssl_openssl_lib;

--- a/component/synapse/sslinux.inc
+++ b/component/synapse/sslinux.inc
@@ -48,7 +48,7 @@
 
 //{$DEFINE FORCEOLDAPI}
 {Note about define FORCEOLDAPI:
-If you activate this compiler directive, then is allways used old socket API
+If you activate this compiler directive, then is always used old socket API
 for name resolution. If you leave this directive inactive, then the new API
 is used, when running system allows it.
 

--- a/component/synapse/ssos2ws1.inc
+++ b/component/synapse/ssos2ws1.inc
@@ -67,7 +67,7 @@ you can install update.
 
 //{$DEFINE FORCEOLDAPI}
 {Note about define FORCEOLDAPI:
-If you activate this compiler directive, then is allways used old socket API
+If you activate this compiler directive, then is always used old socket API
 for name resolution. If you leave this directive inactive, then the new API
 is used, when running system allows it.
 

--- a/component/synapse/ssposix.inc
+++ b/component/synapse/ssposix.inc
@@ -53,7 +53,7 @@
 
 //{$DEFINE FORCEOLDAPI}
 {Note about define FORCEOLDAPI:
-If you activate this compiler directive, then is allways used old socket API
+If you activate this compiler directive, then is always used old socket API
 for name resolution. If you leave this directive inactive, then the new API
 is used, when running system allows it.
 

--- a/component/synapse/sswin32.inc
+++ b/component/synapse/sswin32.inc
@@ -53,7 +53,7 @@ you can install update.
 
 //{$DEFINE FORCEOLDAPI}
 {Note about define FORCEOLDAPI:
-If you activate this compiler directive, then is allways used old socket API
+If you activate this compiler directive, then is always used old socket API
 for name resolution. If you leave this directive inactive, then the new API
 is used, when running system allows it.
 

--- a/component/synapse/synachar.pas
+++ b/component/synapse/synachar.pas
@@ -133,7 +133,7 @@ const
   {:Set of charsets supported by internal routines only.}
   NoIconvChars: set of TMimeChar = [CP895, UTF_7mod];
 
-  {:null character replace table. (Usable for disable charater replacing.)}
+  {:null character replace table. (Usable for disable character replacing.)}
   Replace_None: array[0..0] of Word =
     (0);
 
@@ -197,7 +197,7 @@ function CharsetConversionEx(const Value: AnsiString; CharFrom: TMimeChar;
   CharTo: TMimeChar; const TransformTable: array of Word): AnsiString;
 
 {:Convert Value from one charset to another with additional character conversion.
- This funtion is similar to @link(CharsetConversionEx), but you can disable
+ This function is similar to @link(CharsetConversionEx), but you can disable
  transliteration of unconvertible characters.}
 function CharsetConversionTrans(Value: AnsiString; CharFrom: TMimeChar;
   CharTo: TMimeChar; const TransformTable: array of Word; Translit: Boolean): AnsiString;
@@ -1408,7 +1408,7 @@ begin
   finally
     SynaIconvClose(cd);
   end;
-  //here we allways have ucstring with UCS-2 encoding
+  //here we always have ucstring with UCS-2 encoding
   //second pass... from UCS-2 to target encoding.
     if not DisableIconv then
       if translit then

--- a/component/synapse/synacode.pas
+++ b/component/synapse/synacode.pas
@@ -190,7 +190,7 @@ function EncodeBase64mod(const Value: AnsiString): AnsiString;
 {:Decodes a string from UUcode format.}
 function DecodeUU(const Value: AnsiString): AnsiString;
 
-{:encode UUcode. it encode only datas, you must also add header and footer for
+{:encode UUcode. it encodes only data, you must also add header and footer for
  proper encode.}
 function EncodeUU(const Value: AnsiString): AnsiString;
 
@@ -754,7 +754,7 @@ begin
     1: x :=((x div 3) * 4) + 2;
     2: x :=((x  div 3) * 4) + 3;
   end;
-  //x - lenght UU line
+  //x - length UU line
   s := Copy(Value, 2, x);
   if s = '' then
     Exit;
@@ -793,7 +793,7 @@ begin
     1: x :=((x div 3) * 4) + 2;
     2: x :=((x  div 3) * 4) + 3;
   end;
-  //x - lenght XX line
+  //x - length XX line
   s := Copy(Value, 2, x);
   if s = '' then
     Exit;

--- a/component/synapse/synacrypt.pas
+++ b/component/synapse/synacrypt.pas
@@ -69,7 +69,7 @@ uses
   SysUtils, Classes, synautil, synafpc;
 
 type
-  {:@abstract(Implementation of common routines block ciphers (dafault size is 64-bits))
+  {:@abstract(Implementation of common routines block ciphers (default size is 64-bits))
 
    Do not use this class directly, use descendants only!}
   TSynaBlockCipher= class(TObject)

--- a/component/synapse/synaicnv.pas
+++ b/component/synapse/synaicnv.pas
@@ -57,7 +57,7 @@
 {:@abstract(LibIconv support)
 
 This unit is Pascal interface to LibIconv library for charset translations.
-LibIconv is loaded dynamicly on-demand. If this library is not found in system,
+LibIconv is loaded dynamically on-demand. If this library is not found in system,
 requested LibIconv function just return errorcode.
 }
 unit synaicnv;

--- a/component/synapse/synaip.pas
+++ b/component/synapse/synaip.pas
@@ -42,7 +42,7 @@
 |          (Found at URL: http://www.ararat.cz/synapse/)                       |
 |==============================================================================}
 
-{:@abstract(IP adress support procedures and functions)}
+{:@abstract(IP address support procedures and functions)}
 
 {$IFDEF FPC}
   {$MODE DELPHI}
@@ -65,9 +65,9 @@ uses
   SysUtils, SynaUtil;
 
 type
-{:binary form of IPv6 adress (for string conversion routines)}
+{:binary form of IPv6 address (for string conversion routines)}
   TIp6Bytes = array [0..15] of Byte;
-{:binary form of IPv6 adress (for string conversion routines)}
+{:binary form of IPv6 address (for string conversion routines)}
   TIp6Words = array [0..7] of Word;
 
 {:Returns @TRUE, if "Value" is a valid IPv4 address. Cannot be a symbolic Name!}

--- a/component/synapse/synamisc.pas
+++ b/component/synapse/synamisc.pas
@@ -108,10 +108,10 @@ Type
 {:With this function you can turn on a computer on the network, if this computer
  supports Wake-on-LAN feature. You need the MAC address
  (network card identifier) of the computer. You can also assign a target IP
- addres. If you do not specify it, then broadcast is used to deliver magic
+ address. If you do not specify it, then broadcast is used to deliver magic
  wake-on-LAN packet.
  However broadcasts work only on your local network. When you need to wake-up a
- computer on another network, you must specify any existing IP addres on same
+ computer on another network, you must specify any existing IP address on same
  network segment as targeting computer.}
 procedure WakeOnLan(MAC, IP: string);
 
@@ -361,7 +361,7 @@ const
   AUTO_PROXY_FLAG_DETECTION_RUN             =      $00000004;   // detection has been run
   AUTO_PROXY_FLAG_MIGRATED                  =      $00000008;   // migration has just been done
   AUTO_PROXY_FLAG_DONT_CACHE_PROXY_RESULT   =      $00000010;   // don't cache result of host=proxy name
-  AUTO_PROXY_FLAG_CACHE_INIT_RUN            =      $00000020;   // don't initalize and run unless URL expired
+  AUTO_PROXY_FLAG_CACHE_INIT_RUN            =      $00000020;   // don't initialize and run unless URL expired
   AUTO_PROXY_FLAG_DETECTION_SUSPECT         =      $00000040;   // if we're on a LAN & Modem, with only one IP, bad?!?
   INTERNET_OPTION_PER_CONNECTION_OPTION   = 75;
   WininetDLL = 'WININET.DLL';

--- a/component/synapse/synaser.pas
+++ b/component/synapse/synaser.pas
@@ -435,10 +435,10 @@ type
     {:Connects to the port indicated by comport. Comport can be used in Windows
      style (COM2), or in Linux style (/dev/ttyS1). When you use windows style
      in Linux, then it will be converted to Linux name. And vice versa! However
-     you can specify any device name! (other device names then standart is not
+     you can specify any device name! (other device names then standard is not
      converted!)
 
-     After successfull connection the DTR signal is set (if you not set hardware
+     After successful connection the DTR signal is set (if you not set hardware
      handshake, then the RTS signal is set, too!)
 
      Connection parameters is predefined by your system configuration. If you
@@ -494,7 +494,7 @@ type
     procedure SendStream(const Stream: TStream); virtual;
 
     {:send content of stream as block, but this is compatioble with Indy library.
-     (it have swapped lenght of block). See @link(SendStream)}
+     (it have swapped length of block). See @link(SendStream)}
     procedure SendStreamIndy(const Stream: TStream); virtual;
 
     {:Waits until the allocated buffer is filled by received data. Returns number
@@ -514,7 +514,7 @@ type
      @link(RecvTerminated) methods.}
     function RecvBufferEx(buffer: pointer; length: integer; timeout: integer): integer; virtual;
 
-    {:It is like recvBufferEx, but data is readed to dynamicly allocated binary
+    {:It is like recvBufferEx, but data is read to dynamically allocated binary
      string.}
     function RecvBufferStr(Length: Integer; Timeout: Integer): AnsiString; virtual;
 
@@ -557,16 +557,16 @@ type
      is set to @link(ErrTimeout).}
     function RecvBlock(Timeout: Integer): AnsiString; virtual;
 
-    {:Receive all data to stream, until some error occured. (for example timeout)}
+    {:Receive all data to stream, until some error occurred. (for example timeout)}
     procedure RecvStreamRaw(const Stream: TStream; Timeout: Integer); virtual;
 
     {:receive requested count of bytes to stream}
     procedure RecvStreamSize(const Stream: TStream; Timeout: Integer; Size: Integer); virtual;
 
-    {:receive block of data to stream. (Data can be sended by @link(sendstream)}
+    {:receive block of data to stream. (Data can be sent by @link(sendstream)}
     procedure RecvStream(const Stream: TStream; Timeout: Integer); virtual;
 
-    {:receive block of data to stream. (Data can be sended by @link(sendstreamIndy)}
+    {:receive block of data to stream. (Data can be sent by @link(sendstreamIndy)}
     procedure RecvStreamIndy(const Stream: TStream; Timeout: Integer); virtual;
 
     {:Returns the number of received bytes waiting for reading. 0 is returned
@@ -590,7 +590,7 @@ type
      - On Windows NT (or higher) ir RTS signal driven by system driver.
 
      - On Win9x family is used special code for waiting until last byte is
-      sended from your UART.
+      sent from your UART.
 
      - On Linux you must have kernel 2.1 or higher!}
     procedure EnableRTSToggle(value: boolean); virtual;
@@ -1385,7 +1385,7 @@ begin
   x := 0;
   repeat
     ti := GetTick;
-    //get rest of FBuffer or incomming new data...
+    //get rest of FBuffer or incoming new data...
     s := s + RecvPacket(Timeout);
     if FLastError <> sOK then
       Break;
@@ -2374,7 +2374,7 @@ begin
   //FPC forgot to add getsid.. :-(
   {$IFNDEF FPC}
   if {$IFNDEF POSIX}Libc.{$ENDIF}getsid(ReadLockfile) = -1 then
-  begin //  Lockfile was left from former desaster
+  begin //  Lockfile was left from former disaster
     DeleteFile(Filename); // error recovery
     CreateLockfile(MyPid);
     result := FileExists(Filename);

--- a/component/synapse/tlntsend.pas
+++ b/component/synapse/tlntsend.pas
@@ -88,7 +88,7 @@ const
   TLNT_IAC                = #255;
 
 type
-  {:@abstract(State of telnet protocol). Used internaly by TTelnetSend.}
+  {:@abstract(State of telnet protocol). Used internally by TTelnetSend.}
   TTelnetState =(tsDATA, tsIAC, tsIAC_SB, tsIAC_WILL, tsIAC_DO, tsIAC_WONT,
      tsIAC_DONT, tsIAC_SBIAC, tsIAC_SBDATA, tsSBDATA_IAC);
 
@@ -126,7 +126,7 @@ type
     {:Send this data to telnet server.}
     procedure Send(const Value: string);
 
-    {:Reading data from telnet server until Value is readed. If it is not readed
+    {:Reading data from telnet server until Value is read. If it is not read
      until timeout, result is @false. Otherwise result is @true.}
     function WaitFor(const Value: string): Boolean;
 
@@ -136,14 +136,14 @@ type
     {:Read string from telnet server.}
     function RecvString: string;
   published
-    {:Socket object used for TCP/IP operation. Good for seting OnStatus hook, etc.}
+    {:Socket object used for TCP/IP operation. Good for setting OnStatus hook, etc.}
     property Sock: TTCPBlockSocket read FSock;
 
-    {:all readed datas in this session (from connect) is stored in this large
+    {:all read data in this session (from connect) is stored in this large
      string.}
     property SessionLog: Ansistring read FSessionLog write FSessionLog;
 
-    {:Terminal type indentification. By default is 'SYNAPSE'.}
+    {:Terminal type identification. By default is 'SYNAPSE'.}
     property TermType: Ansistring read FTermType write FTermType;
   end;
 

--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 #
 # create freepascal Makefile to build indistarter
 #
-# syntaxe :
+# syntax :
 #    ./configure [fpcbin=path_to_fpc_binaries] [fpc=path_to_fpc_units]  [lazarus=path_to_lazarus] [prefix=install_path] [target=fpcmake_target]
 #
 
@@ -41,7 +41,7 @@ if [ -z "$fpcbin" ]; then
 fi
 #  Try to locate fpcbin
 if [ -z "$fpcbin" ]; then
-   echo Warning! try to use locate to find FPC path, the option may not work depending your version of locate and the result my be completly wrong. It is better if you specify fpcbin= on the command line.
+   echo Warning! try to use locate to find FPC path, the option may not work depending your version of locate and the result my be completely wrong. It is better if you specify fpcbin= on the command line.
    export fpcbin=$(locate -n1 '\fpcmake'  | sed 's#/fpcmake##')
    echo fpcbin=$fpcbin
    read -p "[Press Enter to continue]"
@@ -63,7 +63,7 @@ if [ -z "$fpc" ]; then
 fi
 #  Try to locate fpc unit 
 if [ -z "$fpc" ]; then
-   echo Warning! try to use locate to find fpc source/units path, the option may not work depending your version of locate and the result my be completly wrong. It is better if you specify fpc= on the command line.
+   echo Warning! try to use locate to find fpc source/units path, the option may not work depending your version of locate and the result my be completely wrong. It is better if you specify fpc= on the command line.
    export fpc=$(locate -n1 rtl/Package.fpc | sed 's#/rtl/Package.fpc##')
    echo fpc=$fpc
    read -p "[Press Enter to continue]"
@@ -85,7 +85,7 @@ if [ -z "$lazarus" ]; then
 fi
 #  Try to locate Lazarus lcl
 if [ -z "$lazarus" ]; then
-   echo Warning! try to use locate to find LAZARUS path, the option may not work depending your version of locate and the result my be completly wrong. It is better if you specify lazarus= on the command line.
+   echo Warning! try to use locate to find LAZARUS path, the option may not work depending your version of locate and the result my be completely wrong. It is better if you specify lazarus= on the command line.
    export lazarus=$(locate -n1 lcl/lclclasses.pp | sed 's#/lcl/lclclasses.pp##')
    echo lazarus=$lazarus
    read -p "[Press Enter to continue]"


### PR DESCRIPTION
Found via `codespell -q 3 -L aixs,aline,daed,datas,dout,ede,larg,maccro,macth,pard,ser,servent,struc,tolen`